### PR TITLE
Calendar Buttons CLI Command Equivalent Update

### DIFF
--- a/docs/UserGuide.adoc
+++ b/docs/UserGuide.adoc
@@ -403,29 +403,33 @@ Shows Calendar in Month-View.
 
 ==== Go to next page in the calendar : `calendarnext` `coming in v1.5`
 
-Goes to the next page in Calendar. +
+Displays next page of current displayed date in calendar. +
 Format: `calendarnext` +
 Command Alias: `calnext`
 
 ****
-* Depending on the current day/week/month calendar is displaying, this command will display the next day/week/month.
+* If calendar is displaying in day-view, command displays the next day of original date in day-view.
+* If calendar is displaying in week-view, command displays the next week of original date in week-view.
+* If calendar is displaying in month-view, command displays next month of original date in month-view.
 ****
 
-==== Go to previous page in the calendar : `calendarprev` `coming in v1.5`
+==== Go to previous page in the calendar : `calendarback` `coming in v1.5`
 
-Goes to the previous page in Calendar. +
-Format: `calendarprev` +
-Command Alias: `calprev`
+Displays previous page of current displayed date in calendar. +
+Format: `calendarback` +
+Command Alias: `calback`
 
 ****
-* Depending on the current day/week/month calendar is displaying, this command will display the previous day/week/month.
+* If calendar is displaying in day-view, command displays the previous day of original date in day-view.
+* If calendar is displaying in week-view, command displays the previous week of original date in week-view.
+* If calendar is displaying in month-view, command displays previous month of original date in month-view.
 ****
 
-==== Display current day in the calendar : `calendarnow` `coming in v1.5`
+==== Display current day in the calendar : `calendartoday` `coming in v1.5`
 
 Displays today's date in Calendar. +
-Format: `calendarnow` +
-Command Alias: `calnow`
+Format: `calendartoday` +
+Command Alias: `caltoday`
 
 ****
 * If calendar is displaying in day-view, command displays today's date in day-view.

--- a/src/main/java/seedu/address/commons/events/ui/ChangeCalendarPageRequestEvent.java
+++ b/src/main/java/seedu/address/commons/events/ui/ChangeCalendarPageRequestEvent.java
@@ -1,0 +1,25 @@
+package seedu.address.commons.events.ui;
+
+import seedu.address.commons.events.BaseEvent;
+
+/**
+ * Indicates request to change page that calendar is displaying.
+ * A page represents a day, week or month, depending on the current view of the calendar.
+ */
+public class ChangeCalendarPageRequestEvent extends BaseEvent {
+
+    private final String requestType;
+
+    public ChangeCalendarPageRequestEvent(String requestType) {
+        this.requestType = requestType;
+    }
+
+    public String getRequestType() {
+        return requestType;
+    }
+
+    @Override
+    public String toString() {
+        return this.getClass().getSimpleName();
+    }
+}

--- a/src/main/java/seedu/address/commons/util/CalendarUtil.java
+++ b/src/main/java/seedu/address/commons/util/CalendarUtil.java
@@ -1,5 +1,5 @@
 package seedu.address.commons.util;
-
+//@@author SuxianAlicia
 import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;

--- a/src/main/java/seedu/address/commons/util/EntryTimeConstraintsUtil.java
+++ b/src/main/java/seedu/address/commons/util/EntryTimeConstraintsUtil.java
@@ -1,5 +1,5 @@
 package seedu.address.commons.util;
-
+//@@author SuxianAlicia
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.time.Duration;

--- a/src/main/java/seedu/address/logic/CommandSyntaxListUtil.java
+++ b/src/main/java/seedu/address/logic/CommandSyntaxListUtil.java
@@ -32,7 +32,7 @@ import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.commands.ViewBackCommand;
 import seedu.address.logic.commands.ViewCalendarCommand;
-import seedu.address.logic.commands.ViewForwardCommand;
+import seedu.address.logic.commands.ViewNextCommand;
 import seedu.address.logic.commands.ViewTodayCommand;
 
 /**
@@ -79,7 +79,7 @@ public final class CommandSyntaxListUtil {
         commandSyntaxList.add(UndoCommand.COMMAND_WORD);
         commandSyntaxList.add(ViewBackCommand.COMMAND_WORD);
         commandSyntaxList.add(ViewCalendarCommand.COMMAND_WORD);
-        commandSyntaxList.add(ViewForwardCommand.COMMAND_WORD);
+        commandSyntaxList.add(ViewNextCommand.COMMAND_WORD);
         commandSyntaxList.add(ViewTodayCommand.COMMAND_WORD);
 
         sortCommandList();

--- a/src/main/java/seedu/address/logic/CommandSyntaxListUtil.java
+++ b/src/main/java/seedu/address/logic/CommandSyntaxListUtil.java
@@ -30,7 +30,10 @@ import seedu.address.logic.commands.ListOrderCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.UndoCommand;
+import seedu.address.logic.commands.ViewBackCommand;
 import seedu.address.logic.commands.ViewCalendarCommand;
+import seedu.address.logic.commands.ViewForwardCommand;
+import seedu.address.logic.commands.ViewTodayCommand;
 
 /**
  * Returns the syntax list of existing commands.
@@ -74,7 +77,10 @@ public final class CommandSyntaxListUtil {
         commandSyntaxList.add(RedoCommand.COMMAND_WORD);
         commandSyntaxList.add(SelectCommand.COMMAND_SYNTAX);
         commandSyntaxList.add(UndoCommand.COMMAND_WORD);
+        commandSyntaxList.add(ViewBackCommand.COMMAND_WORD);
         commandSyntaxList.add(ViewCalendarCommand.COMMAND_WORD);
+        commandSyntaxList.add(ViewForwardCommand.COMMAND_WORD);
+        commandSyntaxList.add(ViewTodayCommand.COMMAND_WORD);
 
         sortCommandList();
     }

--- a/src/main/java/seedu/address/logic/commands/AddEntryCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddEntryCommand.java
@@ -1,5 +1,5 @@
 package seedu.address.logic.commands;
-
+//@@author SuxianAlicia
 import static java.util.Objects.requireNonNull;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_END_DATE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_END_TIME;
@@ -17,9 +17,8 @@ import seedu.address.model.event.CalendarEntry;
 import seedu.address.model.event.exceptions.DuplicateCalendarEntryException;
 
 /**
- * Adds a calendar entry to the address book.
+ * Adds a calendar entry to calendar manager.
  */
-//@@author SuxianAlicia
 public class AddEntryCommand extends UndoableCommand {
 
     public static final String COMMAND_WORD = "entryadd";

--- a/src/main/java/seedu/address/logic/commands/DeleteGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteGroupCommand.java
@@ -1,5 +1,5 @@
 package seedu.address.logic.commands;
-
+//@@author SuxianAlicia
 import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
@@ -11,7 +11,6 @@ import seedu.address.model.tag.exceptions.GroupNotFoundException;
 /**
  * Deletes a group specified by user from address book.
  */
-//@@author SuxianAlicia
 public class DeleteGroupCommand extends UndoableCommand {
 
     public static final String COMMAND_WORD = "groupdelete";

--- a/src/main/java/seedu/address/logic/commands/DeletePreferenceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeletePreferenceCommand.java
@@ -1,5 +1,5 @@
 package seedu.address.logic.commands;
-
+//@@author SuxianAlicia
 import static java.util.Objects.requireNonNull;
 
 import java.util.Objects;
@@ -11,7 +11,6 @@ import seedu.address.model.tag.exceptions.PreferenceNotFoundException;
 /**
  * Deletes a preference specified by user from address book.
  */
-//@@author SuxianAlicia
 public class DeletePreferenceCommand extends UndoableCommand {
 
     public static final String COMMAND_WORD = "prefdelete";

--- a/src/main/java/seedu/address/logic/commands/EditEntryCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditEntryCommand.java
@@ -1,6 +1,5 @@
 package seedu.address.logic.commands;
 //@@ author SuxianAlicia
-
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.EntryTimeConstraintsUtil.checkCalendarEntryTimeConstraints;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_END_DATE;

--- a/src/main/java/seedu/address/logic/commands/FindGroupCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindGroupCommand.java
@@ -1,12 +1,11 @@
 package seedu.address.logic.commands;
-
+//@@author SuxianAlicia
 import seedu.address.model.person.GroupsContainKeywordsPredicate;
 
 /**
  * Finds and lists all persons in address book whose groups contains any of the argument keywords.
  * Keyword matching is case insensitive.
  */
-//@@author SuxianAlicia
 public class FindGroupCommand extends Command {
 
     public static final String COMMAND_WORD = "groupfind";

--- a/src/main/java/seedu/address/logic/commands/FindPreferenceCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FindPreferenceCommand.java
@@ -1,12 +1,11 @@
 package seedu.address.logic.commands;
-
+//@@author SuxianAlicia
 import seedu.address.model.person.PreferencesContainKeywordsPredicate;
 
 /**
  * Finds and lists all persons in address book whose preferences contains any of the argument keywords.
  * Keyword matching is case insensitive.
  */
-//@@author SuxianAlicia
 public class FindPreferenceCommand extends Command {
     public static final String COMMAND_WORD = "preffind";
     public static final String COMMAND_ALIAS = "pf";

--- a/src/main/java/seedu/address/logic/commands/ListCalendarEntryCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCalendarEntryCommand.java
@@ -1,5 +1,5 @@
 package seedu.address.logic.commands;
-
+//@@author SuxianAlicia
 import seedu.address.commons.core.EventsCenter;
 import seedu.address.commons.events.ui.DisplayCalendarEntryListEvent;
 import seedu.address.model.Model;
@@ -7,7 +7,6 @@ import seedu.address.model.Model;
 /**
  * List and display all calendar entries in the address book to the user.
  */
-//@@author SuxianAlicia
 public class ListCalendarEntryCommand extends Command {
     public static final String COMMAND_WORD = "entrylist";
     public static final String COMMAND_ALIAS = "el";

--- a/src/main/java/seedu/address/logic/commands/ListOrderCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListOrderCommand.java
@@ -1,5 +1,5 @@
 package seedu.address.logic.commands;
-
+//@@author SuxianAlicia
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_ORDERS;
 
 import seedu.address.commons.core.EventsCenter;
@@ -8,7 +8,6 @@ import seedu.address.commons.events.ui.DisplayOrderListEvent;
 /**
  * List and display all orders in the address book to the user.
  */
-//@@author SuxianAlicia
 public class ListOrderCommand extends Command {
     public static final String COMMAND_WORD = "orderlist";
     public static final String COMMAND_ALIAS = "ol";

--- a/src/main/java/seedu/address/logic/commands/ViewBackCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewBackCommand.java
@@ -1,0 +1,37 @@
+package seedu.address.logic.commands;
+//@@author SuxianAlicia
+import seedu.address.commons.core.EventsCenter;
+import seedu.address.commons.events.ui.ChangeCalendarPageRequestEvent;
+import seedu.address.logic.commands.exceptions.CommandException;
+
+/**
+ * Switches current page of Calendar to previous page.
+ * Depending on the current viewing format of Calendar, the previous page can be the previous day, previous week,
+ * or previous month of the current displayed date.
+ * This command will display the calendar if it is not displayed when command is executed.
+ */
+public class ViewBackCommand extends Command {
+    public static final String COMMAND_WORD = "calendarback";
+    public static final String COMMAND_ALIAS = "calback";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Displays previous page of current displayed date in calendar.\n"
+            + "Depending on the current viewing format of Calendar, the previous page can be the previous day,"
+            + " previous week, or previous month of the current displayed date.\n"
+            + "Example: " + COMMAND_WORD;
+
+    public static final String MESSAGE_VIEW_CALENDAR_BACK_SUCCESS = "Displayed previous page in Calendar.";
+    public static final String REQUEST_BACK = "Back";
+
+    @Override
+    public CommandResult execute() throws CommandException {
+        EventsCenter.getInstance().post(new ChangeCalendarPageRequestEvent(REQUEST_BACK));
+        return new CommandResult(MESSAGE_VIEW_CALENDAR_BACK_SUCCESS);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ViewBackCommand); // instanceof handles nulls
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/ViewCalendarCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewCalendarCommand.java
@@ -21,7 +21,7 @@ public class ViewCalendarCommand extends Command {
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Displays Calendar in a specified viewing format.\n"
             + "Parameters: [VIEW_FORMAT] (must be either \"day\", \"week\" or \"month\" without captions)\n"
-            + "If no parameters are given or given parameter does not follow the required keywords,"
+            + "If no parameters are given or given parameter does not follow the accepted keywords,"
             + " calendar will display in Day-View.\n"
             + "Example: " + COMMAND_WORD + " day";
 
@@ -34,14 +34,14 @@ public class ViewCalendarCommand extends Command {
     private final String view;
 
     public ViewCalendarCommand(String view) {
+        requireNonNull(view);
         String trimmedView = view.trim();
-        requireNonNull(trimmedView);
 
         if (trimmedView.equalsIgnoreCase(MONTH_VIEW)) {
             this.view = MONTH_VIEW;
         } else if (trimmedView.equalsIgnoreCase(WEEK_VIEW)) {
             this.view = WEEK_VIEW;
-        } else { //If user input is equal to DAY_VIEW or input does not conform to any of the required keywords
+        } else { //If view is equal to DAY_VIEW, is empty or does not match any of the accepted keywords
             this.view = DAY_VIEW;
         }
     }
@@ -58,7 +58,8 @@ public class ViewCalendarCommand extends Command {
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof ViewCalendarCommand); // instanceof handles nulls
+                || (other instanceof ViewCalendarCommand
+                && this.view.equals(((ViewCalendarCommand) other).view)); // instanceof handles nulls
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/ViewCalendarCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewCalendarCommand.java
@@ -1,5 +1,5 @@
 package seedu.address.logic.commands;
-
+//@@author SuxianAlicia
 import static java.util.Objects.requireNonNull;
 
 import java.util.Optional;
@@ -9,27 +9,23 @@ import seedu.address.commons.events.ui.DisplayCalendarRequestEvent;
 import seedu.address.logic.commands.exceptions.CommandException;
 
 /**
- * Displays Calendar in App.
+ * Displays Calendar in ContactSails in 3 possible viewing formats, Day, Week or Month.
  */
-//@@author SuxianAlicia
 public class ViewCalendarCommand extends Command {
     public static final String COMMAND_WORD = "calendar";
     public static final String COMMAND_ALIAS = "cal";
 
-
     public static final String COMMAND_SYNTAX = COMMAND_WORD + " "
             + "[VIEW_FORMAT]";
 
-
     public static final String MESSAGE_USAGE = COMMAND_WORD
-            + ": Displays Calendar in a specified format.\n"
+            + ": Displays Calendar in a specified viewing format.\n"
             + "Parameters: [VIEW_FORMAT] (must be either \"day\", \"week\" or \"month\" without captions)\n"
             + "If no parameters are given or given parameter does not follow the required keywords,"
             + " calendar will display in Day-View.\n"
             + "Example: " + COMMAND_WORD + " day";
 
     public static final String MESSAGE_SHOW_CALENDAR_SUCCESS = "Display Calendar in %1$s-View.";
-
 
     public static final String MONTH_VIEW = "Month";
     public static final String DAY_VIEW = "Day";

--- a/src/main/java/seedu/address/logic/commands/ViewForwardCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewForwardCommand.java
@@ -1,0 +1,37 @@
+package seedu.address.logic.commands;
+//@@author SuxianAlicia
+import seedu.address.commons.core.EventsCenter;
+import seedu.address.commons.events.ui.ChangeCalendarPageRequestEvent;
+import seedu.address.logic.commands.exceptions.CommandException;
+
+/**
+ * Switches current page of Calendar to next page.
+ * Depending on the current viewing format of Calendar, the next page can be the next day, next week
+ * or next month of the current displayed date.
+ * This command will display the calendar if it is not displayed when command is executed.
+ */
+public class ViewForwardCommand extends Command {
+    public static final String COMMAND_WORD = "calendarforward";
+    public static final String COMMAND_ALIAS = "calforward";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Displays next page of current displayed date in calendar.\n"
+            + "Depending on the current viewing format of Calendar, the next page can be the next day,"
+            + " next week or next month of the current displayed date.\n"
+            + "Example: " + COMMAND_WORD;
+
+    public static final String MESSAGE_VIEW_CALENDAR_FORWARD_SUCCESS = "Displayed next page in Calendar.";
+    public static final String REQUEST_FORWARD = "Forward";
+
+    @Override
+    public CommandResult execute() throws CommandException {
+        EventsCenter.getInstance().post(new ChangeCalendarPageRequestEvent(REQUEST_FORWARD));
+        return new CommandResult(MESSAGE_VIEW_CALENDAR_FORWARD_SUCCESS);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ViewBackCommand); // instanceof handles nulls
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/ViewNextCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewNextCommand.java
@@ -10,9 +10,9 @@ import seedu.address.logic.commands.exceptions.CommandException;
  * or next month of the current displayed date.
  * This command will display the calendar if it is not displayed when command is executed.
  */
-public class ViewForwardCommand extends Command {
-    public static final String COMMAND_WORD = "calendarforward";
-    public static final String COMMAND_ALIAS = "calforward";
+public class ViewNextCommand extends Command {
+    public static final String COMMAND_WORD = "calendarnext";
+    public static final String COMMAND_ALIAS = "calnext";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD
             + ": Displays next page of current displayed date in calendar.\n"
@@ -20,18 +20,18 @@ public class ViewForwardCommand extends Command {
             + " next week or next month of the current displayed date.\n"
             + "Example: " + COMMAND_WORD;
 
-    public static final String MESSAGE_VIEW_CALENDAR_FORWARD_SUCCESS = "Displayed next page in Calendar.";
-    public static final String REQUEST_FORWARD = "Forward";
+    public static final String MESSAGE_VIEW_CALENDAR_NEXT_SUCCESS = "Displayed next page in Calendar.";
+    public static final String REQUEST_NEXT = "Next";
 
     @Override
     public CommandResult execute() throws CommandException {
-        EventsCenter.getInstance().post(new ChangeCalendarPageRequestEvent(REQUEST_FORWARD));
-        return new CommandResult(MESSAGE_VIEW_CALENDAR_FORWARD_SUCCESS);
+        EventsCenter.getInstance().post(new ChangeCalendarPageRequestEvent(REQUEST_NEXT));
+        return new CommandResult(MESSAGE_VIEW_CALENDAR_NEXT_SUCCESS);
     }
 
     @Override
     public boolean equals(Object other) {
         return other == this // short circuit if same object
-                || (other instanceof ViewBackCommand); // instanceof handles nulls
+                || (other instanceof ViewNextCommand); // instanceof handles nulls
     }
 }

--- a/src/main/java/seedu/address/logic/commands/ViewTodayCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ViewTodayCommand.java
@@ -1,0 +1,33 @@
+package seedu.address.logic.commands;
+//@@author SuxianAlicia
+import seedu.address.commons.core.EventsCenter;
+import seedu.address.commons.events.ui.ChangeCalendarPageRequestEvent;
+import seedu.address.logic.commands.exceptions.CommandException;
+
+/**
+ * Switches currently displayed date in Calendar to today's date.
+ * This command will display the calendar if it is not displayed when command is executed.
+ */
+public class ViewTodayCommand extends Command {
+    public static final String COMMAND_WORD = "calendartoday";
+    public static final String COMMAND_ALIAS = "caltoday";
+
+    public static final String MESSAGE_USAGE = COMMAND_WORD
+            + ": Displays today's date in calendar.\n"
+            + "Example: " + COMMAND_WORD;
+
+    public static final String MESSAGE_VIEW_CALENDAR_TODAY_SUCCESS = "Displayed Today in Calendar.";
+    public static final String REQUEST_TODAY = "Today";
+
+    @Override
+    public CommandResult execute() throws CommandException {
+        EventsCenter.getInstance().post(new ChangeCalendarPageRequestEvent(REQUEST_TODAY));
+        return new CommandResult(MESSAGE_VIEW_CALENDAR_TODAY_SUCCESS);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof ViewTodayCommand); // instanceof handles nulls
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/AddEntryCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddEntryCommandParser.java
@@ -1,5 +1,5 @@
 package seedu.address.logic.parser;
-
+//@@author SuxianAlicia
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.util.EntryTimeConstraintsUtil.checkCalendarEntryTimeConstraints;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_END_DATE;
@@ -23,7 +23,6 @@ import seedu.address.model.event.StartTime;
 /**
  * Parses input arguments and creates a new AddEntryCommand object
  */
-//@@author SuxianAlicia
 public class AddEntryCommandParser implements Parser<AddEntryCommand> {
 
     public static final String STANDARD_START_TIME = "00:00"; //Start Time of event if StartTime not given

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -35,7 +35,7 @@ import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.UndoCommand;
 import seedu.address.logic.commands.ViewBackCommand;
 import seedu.address.logic.commands.ViewCalendarCommand;
-import seedu.address.logic.commands.ViewForwardCommand;
+import seedu.address.logic.commands.ViewNextCommand;
 import seedu.address.logic.commands.ViewTodayCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
@@ -178,9 +178,9 @@ public class AddressBookParser {
         case ViewCalendarCommand.COMMAND_ALIAS:
             return new ViewCalendarCommand(arguments);
 
-        case ViewForwardCommand.COMMAND_WORD:
-        case ViewForwardCommand.COMMAND_ALIAS:
-            return new ViewForwardCommand();
+        case ViewNextCommand.COMMAND_WORD:
+        case ViewNextCommand.COMMAND_ALIAS:
+            return new ViewNextCommand();
 
         case ViewTodayCommand.COMMAND_WORD:
         case ViewTodayCommand.COMMAND_ALIAS:

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -33,7 +33,10 @@ import seedu.address.logic.commands.ListOrderCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.UndoCommand;
+import seedu.address.logic.commands.ViewBackCommand;
 import seedu.address.logic.commands.ViewCalendarCommand;
+import seedu.address.logic.commands.ViewForwardCommand;
+import seedu.address.logic.commands.ViewTodayCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -167,9 +170,21 @@ public class AddressBookParser {
         case RedoCommand.COMMAND_ALIAS:
             return new RedoCommand();
 
+        case ViewBackCommand.COMMAND_WORD:
+        case ViewBackCommand.COMMAND_ALIAS:
+            return new ViewBackCommand();
+
         case ViewCalendarCommand.COMMAND_WORD:
         case ViewCalendarCommand.COMMAND_ALIAS:
             return new ViewCalendarCommand(arguments);
+
+        case ViewForwardCommand.COMMAND_WORD:
+        case ViewForwardCommand.COMMAND_ALIAS:
+            return new ViewForwardCommand();
+
+        case ViewTodayCommand.COMMAND_WORD:
+        case ViewTodayCommand.COMMAND_ALIAS:
+            return new ViewTodayCommand();
 
         default:
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);

--- a/src/main/java/seedu/address/logic/parser/DeleteEntryCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteEntryCommandParser.java
@@ -1,5 +1,5 @@
 package seedu.address.logic.parser;
-
+//@@author SuxianAlicia
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import seedu.address.commons.core.index.Index;
@@ -10,7 +10,6 @@ import seedu.address.logic.parser.exceptions.ParseException;
 /**
  * Parses input arguments and creates a new DeleteEntryCommand object
  */
-//@@author SuxianAlicia
 public class DeleteEntryCommandParser implements Parser<DeleteEntryCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of the DeleteEntryCommand

--- a/src/main/java/seedu/address/logic/parser/DeleteGroupCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteGroupCommandParser.java
@@ -1,5 +1,5 @@
 package seedu.address.logic.parser;
-
+//@@author SuxianAlicia
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import seedu.address.commons.exceptions.IllegalValueException;
@@ -12,7 +12,6 @@ import seedu.address.model.tag.Group;
  * and returns an DeleteGroupCommand object for execution.
  * @throws ParseException if the user input does not conform the expected format
  */
-//@@author SuxianAlicia
 public class DeleteGroupCommandParser implements Parser<DeleteGroupCommand> {
 
     @Override

--- a/src/main/java/seedu/address/logic/parser/DeletePreferenceCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeletePreferenceCommandParser.java
@@ -1,5 +1,5 @@
 package seedu.address.logic.parser;
-
+//@@author SuxianAlicia
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import seedu.address.commons.exceptions.IllegalValueException;
@@ -12,7 +12,6 @@ import seedu.address.model.tag.Preference;
  * and returns an DeletePreferenceCommand object for execution.
  * @throws ParseException if the user input does not conform the expected format
  */
-//@@author SuxianAlicia
 public class DeletePreferenceCommandParser implements Parser<DeletePreferenceCommand> {
     @Override
     public DeletePreferenceCommand parse(String userInput) throws ParseException {

--- a/src/main/java/seedu/address/logic/parser/EditEntryCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditEntryCommandParser.java
@@ -1,5 +1,5 @@
 package seedu.address.logic.parser;
-
+//@@author SuxianAlicia
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_END_DATE;

--- a/src/main/java/seedu/address/logic/parser/FindGroupCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindGroupCommandParser.java
@@ -1,5 +1,5 @@
 package seedu.address.logic.parser;
-
+//@@author SuxianAlicia
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.util.Arrays;
@@ -11,7 +11,6 @@ import seedu.address.model.person.GroupsContainKeywordsPredicate;
 /**
  * Parses input arguments and creates a new FindGroupCommand object
  */
-//@@author SuxianAlicia
 public class FindGroupCommandParser implements Parser<FindGroupCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of the FindGroupCommand

--- a/src/main/java/seedu/address/logic/parser/FindPreferenceCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FindPreferenceCommandParser.java
@@ -1,5 +1,5 @@
 package seedu.address.logic.parser;
-
+//@@author SuxianAlicia
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 
 import java.util.Arrays;
@@ -11,7 +11,6 @@ import seedu.address.model.person.PreferencesContainKeywordsPredicate;
 /**
  * Parses input arguments and creates a new FindPreferenceCommand object
  */
-//@@author SuxianAlicia
 public class FindPreferenceCommandParser implements Parser<FindPreferenceCommand> {
     /**
      * Parses the given {@code String} of arguments in the context of the FindPreferenceCommand

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -220,6 +220,7 @@ public class AddressBook implements ReadOnlyAddressBook {
         prefTags.add(p);
     }
 
+    //@@author SuxianAlicia
     /**
      * Removes group from all persons who has the group
      * @throws GroupNotFoundException if the {@code toRemove} is not in this {@code AddressBook}.
@@ -275,6 +276,8 @@ public class AddressBook implements ReadOnlyAddressBook {
         }
         setPreferenceTags(newList.toSet());
     }
+    //@@author
+
     //@@author amad-person
     //// order-level operations
 

--- a/src/main/java/seedu/address/model/CalendarManager.java
+++ b/src/main/java/seedu/address/model/CalendarManager.java
@@ -1,5 +1,5 @@
 package seedu.address.model;
-
+//@@author SuxianAlicia
 import static java.util.Objects.requireNonNull;
 
 import java.util.ArrayList;
@@ -18,7 +18,6 @@ import seedu.address.model.event.exceptions.DuplicateCalendarEntryException;
 /**
  * Manages {@code Calendar} as defined in CalendarFX and its related data.
  */
-//@@author SuxianAlicia
 public class CalendarManager implements ReadOnlyCalendarManager {
     private final Calendar calendar;
     private final UniqueCalendarEntryList calendarEntryList;

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -121,8 +121,8 @@ public interface Model {
 
     /** Returns the CalendarManager */
     ReadOnlyCalendarManager getCalendarManager();
-
     //@@author
+
     /**
      * Replaces the given order {@code target} with {@code editedOrder}.
      *

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -75,20 +75,24 @@ public class ModelManager extends ComponentManager implements Model {
         return addressBook;
     }
 
+    //@@author SuxianAlicia
     @Override
     public ReadOnlyCalendarManager getCalendarManager() {
         return calendarManager;
     }
+    //@@author
 
     /** Raises an event to indicate address book has changed */
     private void indicateAddressBookChanged() {
         raise(new AddressBookChangedEvent(addressBook));
     }
 
+    //@@author SuxianAlicia
     /** Raises an event to indicate calendar manager has changed */
     private void indicateCalendarManagerChanged() {
         raise(new CalendarManagerChangedEvent(calendarManager));
     }
+    //@@author
 
     @Override
     public synchronized void deletePerson(Person target) throws PersonNotFoundException {
@@ -112,6 +116,7 @@ public class ModelManager extends ComponentManager implements Model {
         indicateAddressBookChanged();
     }
 
+    //@@author SuxianAlicia
     @Override
     public void deleteGroup(Group targetGroup) throws GroupNotFoundException {
         addressBook.removeGroup(targetGroup);
@@ -123,6 +128,7 @@ public class ModelManager extends ComponentManager implements Model {
         addressBook.removePreference(targetPreference);
         indicateAddressBookChanged();
     }
+    //@@author
 
     //@@author amad-person
     @Override
@@ -147,7 +153,6 @@ public class ModelManager extends ComponentManager implements Model {
         updateFilteredCalendarEventList(PREDICATE_SHOW_ALL_CALENDAR_ENTRIES);
         indicateCalendarManagerChanged();
     }
-
 
     @Override
     public void deleteCalendarEntry(CalendarEntry entryToDelete) throws CalendarEntryNotFoundException {
@@ -237,8 +242,8 @@ public class ModelManager extends ComponentManager implements Model {
     public Calendar getCalendar() {
         return calendarManager.getCalendar();
     }
-
     //@@author
+
     @Override
     public boolean equals(Object obj) {
         // short circuit if same object

--- a/src/main/java/seedu/address/model/ReadOnlyCalendarManager.java
+++ b/src/main/java/seedu/address/model/ReadOnlyCalendarManager.java
@@ -1,12 +1,11 @@
 package seedu.address.model;
-
+//@@author SuxianAlicia
 import javafx.collections.ObservableList;
 import seedu.address.model.event.CalendarEntry;
 
 /**
  * Unmodifiable view of an calendar manager.
  */
-//@@author SuxianAlicia
 public interface ReadOnlyCalendarManager {
 
     /**

--- a/src/main/java/seedu/address/model/event/CalendarEntry.java
+++ b/src/main/java/seedu/address/model/event/CalendarEntry.java
@@ -1,5 +1,5 @@
 package seedu.address.model.event;
-
+//@@author SuxianAlicia
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.util.Objects;
@@ -8,7 +8,6 @@ import java.util.Objects;
  * Represents a Calendar Event in address book.
  * Guarantees: details are present and not null, field values are validated, immutable.
  */
-//@@author SuxianAlicia
 public class CalendarEntry {
 
     private final EntryTitle entryTitle;

--- a/src/main/java/seedu/address/model/event/EndDate.java
+++ b/src/main/java/seedu/address/model/event/EndDate.java
@@ -1,5 +1,5 @@
 package seedu.address.model.event;
-
+//@@author SuxianAlicia
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 import static seedu.address.commons.util.DateUtil.convertStringToDate;
@@ -12,7 +12,6 @@ import java.time.format.DateTimeParseException;
  * Represents Ending Date of a {@code CalendarEntry}.
  * Guarantees: immutable; is valid as declared in {@link seedu.address.commons.util.DateUtil#isValidDate(String)}
  */
-//@@author SuxianAlicia
 public class EndDate {
     public static final String MESSAGE_END_DATE_CONSTRAINTS =
             "End Date should be DD-MM-YYYY, and it should not be blank";

--- a/src/main/java/seedu/address/model/event/EndTime.java
+++ b/src/main/java/seedu/address/model/event/EndTime.java
@@ -1,5 +1,5 @@
 package seedu.address.model.event;
-
+//@@author SuxianAlicia
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 import static seedu.address.commons.util.TimeUtil.convertStringToTime;
@@ -12,7 +12,6 @@ import java.time.format.DateTimeParseException;
  * Represents ending Time of a {@code CalendarEntry}.
  * Guarantees: immutable; is valid as declared in {@link seedu.address.commons.util.TimeUtil#isValidTime(String)}
  */
-//@@author SuxianAlicia
 public class EndTime {
 
     public static final String MESSAGE_END_TIME_CONSTRAINTS =

--- a/src/main/java/seedu/address/model/event/EntryTitle.java
+++ b/src/main/java/seedu/address/model/event/EntryTitle.java
@@ -1,5 +1,5 @@
 package seedu.address.model.event;
-
+//@@author SuxianAlicia
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 
@@ -7,7 +7,6 @@ import static seedu.address.commons.util.AppUtil.checkArgument;
  * Represents Title of a {@code CalendarEntry} in Event list of Address Book.
  * Guarantees: immutable; is valid as declared in {@link #isValidEntryTitle(String)}
  */
-//@@author SuxianAlicia
 public class EntryTitle {
     public static final String MESSAGE_ENTRY_TITLE_CONSTRAINTS =
             "Event title should only contain alphanumeric characters and spaces"

--- a/src/main/java/seedu/address/model/event/StartDate.java
+++ b/src/main/java/seedu/address/model/event/StartDate.java
@@ -1,5 +1,5 @@
 package seedu.address.model.event;
-
+//@@author SuxianAlicia
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 import static seedu.address.commons.util.DateUtil.convertStringToDate;
@@ -12,7 +12,6 @@ import java.time.format.DateTimeParseException;
  * Represents Starting Date of a {@code CalendarEntry}.
  * Guarantees: immutable; is valid as declared in {@link seedu.address.commons.util.DateUtil#isValidDate(String)}
  */
-//@@author SuxianAlicia
 public class StartDate {
     public static final String MESSAGE_START_DATE_CONSTRAINTS =
             "Start Date should be DD-MM-YYYY, and it should not be blank";

--- a/src/main/java/seedu/address/model/event/StartTime.java
+++ b/src/main/java/seedu/address/model/event/StartTime.java
@@ -1,5 +1,5 @@
 package seedu.address.model.event;
-
+//@@author SuxianAlicia
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.AppUtil.checkArgument;
 import static seedu.address.commons.util.TimeUtil.convertStringToTime;
@@ -12,7 +12,6 @@ import java.time.format.DateTimeParseException;
  * Represents starting Time of a {@code CalendarEntry}.
  * Guarantees: immutable; is valid as declared in {@link seedu.address.commons.util.TimeUtil#isValidTime(String)}
  */
-//@@author SuxianAlicia
 public class StartTime {
     public static final String MESSAGE_START_TIME_CONSTRAINTS =
             "Start Time should be HH:mm (24Hour Format), and it should not be blank";

--- a/src/main/java/seedu/address/model/event/UniqueCalendarEntryList.java
+++ b/src/main/java/seedu/address/model/event/UniqueCalendarEntryList.java
@@ -1,5 +1,5 @@
 package seedu.address.model.event;
-
+//@@author SuxianAlicia
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
@@ -20,7 +20,6 @@ import seedu.address.model.event.exceptions.DuplicateCalendarEntryException;
  *
  * @see CalendarEntry#equals(Object)
  */
-//@@author SuxianAlicia
 public class UniqueCalendarEntryList implements Iterable<CalendarEntry> {
     private final ObservableList<CalendarEntry> internalList = FXCollections.observableArrayList();
 

--- a/src/main/java/seedu/address/model/event/exceptions/CalendarEntryNotFoundException.java
+++ b/src/main/java/seedu/address/model/event/exceptions/CalendarEntryNotFoundException.java
@@ -1,8 +1,7 @@
 package seedu.address.model.event.exceptions;
-
+//@@author SuxianAlicia
 /**
  * Signals that the operation is unable to find the specified CalendarEntry.
  */
-//@@author SuxianAlicia
 public class CalendarEntryNotFoundException extends Exception {
 }

--- a/src/main/java/seedu/address/model/event/exceptions/DuplicateCalendarEntryException.java
+++ b/src/main/java/seedu/address/model/event/exceptions/DuplicateCalendarEntryException.java
@@ -1,11 +1,10 @@
 package seedu.address.model.event.exceptions;
-
+//@@author SuxianAlicia
 import seedu.address.commons.exceptions.DuplicateDataException;
 
 /**
  * Signals that an operation would have violated the 'no duplicates' property of the list.
  */
-//@@author SuxianAlicia
 public class DuplicateCalendarEntryException extends DuplicateDataException {
 
     public DuplicateCalendarEntryException() {

--- a/src/main/java/seedu/address/model/person/GroupsContainKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/GroupsContainKeywordsPredicate.java
@@ -1,5 +1,5 @@
 package seedu.address.model.person;
-
+//@@author SuxianAlicia
 import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -10,7 +10,6 @@ import seedu.address.commons.util.StringUtil;
 /**
  * Tests that a {@code Person} 's {@code Group}s' names matches any of the keywords given.
  */
-//@@author SuxianAlicia
 public class GroupsContainKeywordsPredicate implements Predicate<Person> {
     private final List<String> keywords;
 

--- a/src/main/java/seedu/address/model/person/PreferencesContainKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/person/PreferencesContainKeywordsPredicate.java
@@ -1,5 +1,5 @@
 package seedu.address.model.person;
-
+//@@author SuxianAlicia
 import java.util.List;
 import java.util.Set;
 import java.util.function.Predicate;
@@ -10,7 +10,6 @@ import seedu.address.commons.util.StringUtil;
 /**
  * Tests that a {@code Person} 's {@code Preference}s' names matches any of the keywords given.
  */
-//@@author SuxianAlicia
 public class PreferencesContainKeywordsPredicate implements Predicate<Person> {
     private final List<String> keywords;
 

--- a/src/main/java/seedu/address/model/tag/Group.java
+++ b/src/main/java/seedu/address/model/tag/Group.java
@@ -1,5 +1,5 @@
 package seedu.address.model.tag;
-
+//@@author SuxianAlicia
 /**
  * Represents a Group in the address book.
  * Guarantees: immutable; name is valid as declared in {@link #isValidTagName(String)} in parent class.

--- a/src/main/java/seedu/address/model/tag/Preference.java
+++ b/src/main/java/seedu/address/model/tag/Preference.java
@@ -1,5 +1,5 @@
 package seedu.address.model.tag;
-
+//@@author SuxianAlicia
 /**
  * Represents a Preference in the address book.
  * Guarantees: immutable; name is valid as declared in {@link #isValidTagName(String)} in parent class.

--- a/src/main/java/seedu/address/model/tag/UniqueGroupList.java
+++ b/src/main/java/seedu/address/model/tag/UniqueGroupList.java
@@ -1,5 +1,5 @@
 package seedu.address.model.tag;
-
+//@@author SuxianAlicia-reused
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 

--- a/src/main/java/seedu/address/model/tag/UniquePreferenceList.java
+++ b/src/main/java/seedu/address/model/tag/UniquePreferenceList.java
@@ -1,5 +1,5 @@
 package seedu.address.model.tag;
-
+//@@author SuxianAlicia-reused
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 

--- a/src/main/java/seedu/address/model/util/SampleDataUtil.java
+++ b/src/main/java/seedu/address/model/util/SampleDataUtil.java
@@ -79,8 +79,13 @@ public class SampleDataUtil {
         return prefTags;
     }
 
+    //@@author SuxianAlicia
+    /**
+     * Returns a {@code CalendarManager} with no {@code CalendarEntry} in it.
+     */
     public static ReadOnlyCalendarManager getSampleCalendarManager() {
         CalendarManager sampleCm = new CalendarManager();
         return sampleCm;
     }
+    //@@author
 }

--- a/src/main/java/seedu/address/storage/CalendarManagerStorage.java
+++ b/src/main/java/seedu/address/storage/CalendarManagerStorage.java
@@ -1,5 +1,5 @@
 package seedu.address.storage;
-
+//@@author SuxianAlicia
 import java.io.IOException;
 import java.util.Optional;
 
@@ -9,7 +9,6 @@ import seedu.address.model.ReadOnlyCalendarManager;
 /**
  * Represents a storage for {@link seedu.address.model.CalendarManager}.
  */
-//@@author SuxianAlicia
 public interface CalendarManagerStorage {
     /**
      * Returns the file path of the data file.

--- a/src/main/java/seedu/address/storage/XmlAdaptedCalendarEntry.java
+++ b/src/main/java/seedu/address/storage/XmlAdaptedCalendarEntry.java
@@ -1,5 +1,5 @@
 package seedu.address.storage;
-
+//@@author SuxianAlicia
 import static seedu.address.commons.util.EntryTimeConstraintsUtil.checkCalendarEntryTimeConstraints;
 
 import java.util.Objects;
@@ -19,7 +19,6 @@ import seedu.address.model.event.StartTime;
 /**
  * JAXB-friendly version of a CalendarEntry.
  */
-//@@author SuxianAlicia
 public class XmlAdaptedCalendarEntry {
 
     public static final String MISSING_FIELD_MESSAGE_FORMAT = "CalendarEntry's %s field is missing!";

--- a/src/main/java/seedu/address/storage/XmlCalendarManagerStorage.java
+++ b/src/main/java/seedu/address/storage/XmlCalendarManagerStorage.java
@@ -1,5 +1,5 @@
 package seedu.address.storage;
-
+//@@author SuxianAlicia
 import static java.util.Objects.requireNonNull;
 
 import java.io.File;
@@ -16,7 +16,6 @@ import seedu.address.model.ReadOnlyCalendarManager;
 /**
  * A class to access CalendarManager data stored as an xml file on the hard disk.
  */
-//@@author SuxianAlicia
 public class XmlCalendarManagerStorage implements CalendarManagerStorage {
 
     private static final Logger logger = LogsCenter.getLogger(XmlAddressBookStorage.class);

--- a/src/main/java/seedu/address/storage/XmlSerializableCalendarManager.java
+++ b/src/main/java/seedu/address/storage/XmlSerializableCalendarManager.java
@@ -1,5 +1,5 @@
 package seedu.address.storage;
-
+//@@author SuxianAlicia
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -14,7 +14,6 @@ import seedu.address.model.ReadOnlyCalendarManager;
 /**
  * An Immutable CalendarManager that is serializable to XML format
  */
-//@@author SuxianAlicia
 @XmlRootElement(name = "calendarmanager")
 public class XmlSerializableCalendarManager {
     @XmlElement

--- a/src/main/java/seedu/address/ui/CalendarEntryCard.java
+++ b/src/main/java/seedu/address/ui/CalendarEntryCard.java
@@ -1,5 +1,5 @@
 package seedu.address.ui;
-
+//@@author SuxianAlicia
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.HBox;
@@ -9,7 +9,6 @@ import seedu.address.model.event.CalendarEntry;
 /**
  * An UI component that displays information of a {@code CalendarEntry}.
  */
-//@@author SuxianAlicia
 public class CalendarEntryCard extends UiPart<Region> {
 
     private static final String FXML = "CalendarEntryCard.fxml";

--- a/src/main/java/seedu/address/ui/CalendarEntryListPanel.java
+++ b/src/main/java/seedu/address/ui/CalendarEntryListPanel.java
@@ -1,5 +1,5 @@
 package seedu.address.ui;
-
+//@@author SuxianAlicia
 import java.util.logging.Logger;
 
 import org.fxmisc.easybind.EasyBind;
@@ -16,7 +16,6 @@ import seedu.address.model.event.CalendarEntry;
 /**
  * Panel containing calendar entries present in calendar.
  */
-//@@author SuxianAlicia
 public class CalendarEntryListPanel extends UiPart<Region> {
 
     private static final String FXML = "CalendarEntryListPanel.fxml";

--- a/src/main/java/seedu/address/ui/CalendarPanel.java
+++ b/src/main/java/seedu/address/ui/CalendarPanel.java
@@ -7,7 +7,6 @@ import java.util.logging.Logger;
 import com.calendarfx.model.Calendar;
 import com.calendarfx.model.CalendarSource;
 import com.calendarfx.view.CalendarView;
-import com.google.common.eventbus.Subscribe;
 
 import javafx.application.Platform;
 import javafx.fxml.FXML;
@@ -31,7 +30,7 @@ public class CalendarPanel extends UiPart<Region> {
 
     private static final String REQUEST_TODAY = "Today";
     private static final String REQUEST_BACK = "Back";
-    private static final String REQUEST_FORWARD = "Forward";
+    private static final String REQUEST_NEXT = "Next";
 
     private static final String FXML = "CalendarPanel.fxml";
 
@@ -114,11 +113,11 @@ public class CalendarPanel extends UiPart<Region> {
     public void handleChangeCalendarPageRequestEvent(ChangeCalendarPageRequestEvent event) {
         logger.info(LogsCenter.getEventHandlingLogMessage(event));
         String request = event.getRequestType();
-        if(request.equals(REQUEST_TODAY)) {
+        if (request.equals(REQUEST_TODAY)) {
             calendarView.getSelectedPage().goToday();
         } else if (request.equals(REQUEST_BACK)) {
             calendarView.getSelectedPage().goBack();
-        } else if (request.equals(REQUEST_FORWARD)) {
+        } else if (request.equals(REQUEST_NEXT)) {
             calendarView.getSelectedPage().goForward();
         }
     }

--- a/src/main/java/seedu/address/ui/CalendarPanel.java
+++ b/src/main/java/seedu/address/ui/CalendarPanel.java
@@ -1,5 +1,5 @@
 package seedu.address.ui;
-
+//@@author SuxianAlicia
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.util.logging.Logger;
@@ -15,6 +15,7 @@ import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
 
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.commons.events.ui.ChangeCalendarPageRequestEvent;
 import seedu.address.commons.events.ui.DisplayCalendarRequestEvent;
 import seedu.address.ui.util.CalendarFxUtil;
 
@@ -22,12 +23,15 @@ import seedu.address.ui.util.CalendarFxUtil;
  * Calendar Panel displaying calendar.
  * ContactSails implements CalendarFX to display Calendar.
  */
-//@@author SuxianAlicia
 public class CalendarPanel extends UiPart<Region> {
 
-    public static final String DAY_VIEW = "Day";
-    public static final String MONTH_VIEW = "Month";
-    public static final String WEEK_VIEW = "Week";
+    private static final String DAY_VIEW = "Day";
+    private static final String MONTH_VIEW = "Month";
+    private static final String WEEK_VIEW = "Week";
+
+    private static final String REQUEST_TODAY = "Today";
+    private static final String REQUEST_BACK = "Back";
+    private static final String REQUEST_FORWARD = "Forward";
 
     private static final String FXML = "CalendarPanel.fxml";
 
@@ -46,7 +50,6 @@ public class CalendarPanel extends UiPart<Region> {
 
         initialiseCalendar(calendar);
         createTimeThread();
-        registerAsAnEventHandler(this);
     }
 
     /**
@@ -88,7 +91,9 @@ public class CalendarPanel extends UiPart<Region> {
         calendarPanelholder.getChildren().setAll(calendarView);
     }
 
-    @Subscribe
+    /**
+     * Handles Request to display Calendar in specific viewing format.
+     */
     public void handleDisplayCalendarRequestEvent(DisplayCalendarRequestEvent event) {
         logger.info(LogsCenter.getEventHandlingLogMessage(event));
         String view = event.getView();
@@ -103,4 +108,18 @@ public class CalendarPanel extends UiPart<Region> {
         }
     }
 
+    /**
+     * Handles request to change the current page of the Calendar.
+     */
+    public void handleChangeCalendarPageRequestEvent(ChangeCalendarPageRequestEvent event) {
+        logger.info(LogsCenter.getEventHandlingLogMessage(event));
+        String request = event.getRequestType();
+        if(request.equals(REQUEST_TODAY)) {
+            calendarView.getSelectedPage().goToday();
+        } else if (request.equals(REQUEST_BACK)) {
+            calendarView.getSelectedPage().goBack();
+        } else if (request.equals(REQUEST_FORWARD)) {
+            calendarView.getSelectedPage().goForward();
+        }
+    }
 }

--- a/src/main/java/seedu/address/ui/CentrePanel.java
+++ b/src/main/java/seedu/address/ui/CentrePanel.java
@@ -1,5 +1,5 @@
 package seedu.address.ui;
-
+//@@author SuxianAlicia
 import com.calendarfx.model.Calendar;
 import com.google.common.eventbus.Subscribe;
 
@@ -7,6 +7,7 @@ import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.layout.Region;
 import javafx.scene.layout.StackPane;
+import seedu.address.commons.events.ui.ChangeCalendarPageRequestEvent;
 import seedu.address.commons.events.ui.DisplayCalendarRequestEvent;
 import seedu.address.commons.events.ui.PersonPanelSelectionChangedEvent;
 import seedu.address.commons.events.ui.ResetPersonPanelEvent;
@@ -14,9 +15,10 @@ import seedu.address.model.event.CalendarEntry;
 
 
 /**
- * The Centre Panel of the App that can switch between Person Panel and Calendar Panel
+ * The Centre Panel of the App that can switch between Person Panel and Calendar Panel.
+ * Centre Panel subscribes to Events meant for Person Panel and Calendar Panel
+ * in order to handle the switching between the displays.
  */
-//@@author SuxianAlicia
 public class CentrePanel extends UiPart<Region> {
 
     private static final String FXML = "CentrePanel.fxml";
@@ -59,6 +61,12 @@ public class CentrePanel extends UiPart<Region> {
     @Subscribe
     private void handleDisplayCalendarRequestEvent(DisplayCalendarRequestEvent event) {
         calendarPanel.handleDisplayCalendarRequestEvent(event);
+        displayCalendarPanel();
+    }
+
+    @Subscribe
+    public void handleChangeCalendarPageRequestEvent(ChangeCalendarPageRequestEvent event) {
+        calendarPanel.handleChangeCalendarPageRequestEvent(event);
         displayCalendarPanel();
     }
 

--- a/src/test/java/seedu/address/logic/commands/ViewBackCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewBackCommandTest.java
@@ -1,0 +1,61 @@
+package seedu.address.logic.commands;
+//@@author SuxianAlicia
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import seedu.address.commons.events.ui.ChangeCalendarPageRequestEvent;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.ui.testutil.EventsCollectorRule;
+
+public class ViewBackCommandTest {
+
+    @Rule
+    public final EventsCollectorRule eventsCollectorRule = new EventsCollectorRule();
+
+    @Test
+    public void execute_viewBackCommand_success() {
+        assertShowPreviousPageSuccess();
+    }
+
+    @Test
+    public void equals() {
+        ViewBackCommand viewBackCommand = new ViewBackCommand();
+
+        // same object -> returns true
+        assertTrue(viewBackCommand.equals(viewBackCommand));
+
+        // same values -> returns true
+        ViewBackCommand viewBackCommandCopy = new ViewBackCommand();
+        assertTrue(viewBackCommand.equals(viewBackCommandCopy));
+
+        // different types -> returns false
+        assertFalse(viewBackCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(viewBackCommand.equals(null));
+    }
+
+    /**
+     * Executes a {@code ViewBackCommand},
+     * and checks that {@code ChangeCalendarPageRequestEvent} is raised with the Request Type "Back".
+     */
+    private void assertShowPreviousPageSuccess() {
+        ViewBackCommand viewBackCommand = new ViewBackCommand();
+
+        try {
+            CommandResult commandResult = viewBackCommand.execute();
+            assertEquals(ViewBackCommand.MESSAGE_VIEW_CALENDAR_BACK_SUCCESS,
+                    commandResult.feedbackToUser);
+        } catch (CommandException ce) {
+            throw new IllegalArgumentException("Execution of command should not fail.", ce);
+        }
+
+        ChangeCalendarPageRequestEvent lastEvent = (ChangeCalendarPageRequestEvent) eventsCollectorRule.eventsCollector
+                .getMostRecent();
+        assertEquals(ViewBackCommand.REQUEST_BACK, lastEvent.getRequestType());
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/ViewCalendarCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewCalendarCommandTest.java
@@ -1,7 +1,123 @@
 package seedu.address.logic.commands;
+//@@author SuxianAlicia
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
+import org.junit.Rule;
+import org.junit.Test;
+
+import seedu.address.commons.events.ui.DisplayCalendarRequestEvent;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.ui.testutil.EventsCollectorRule;
 
 public class ViewCalendarCommandTest {
 
+    @Rule
+    public final EventsCollectorRule eventsCollectorRule = new EventsCollectorRule();
+
+    @Test
+    public void execute_showDayView_success() {
+        assertShowDayViewSuccess("Day"); // Matches exact keyword in ViewCalendarCommand.DAY_VIEW
+        assertShowDayViewSuccess("DAY"); // Case insensitive -> Success
+        assertShowDayViewSuccess(""); // Empty string -> Success as Calendar shows Day page by default.
+        assertShowDayViewSuccess("invalidDay"); // Parameter not matching the accepted keyword -> Success
+    }
+
+    @Test
+    public void execute_showWeekView_success() {
+        assertShowWeekViewSuccess("Week"); // Matches exact keyword in ViewCalendarCommand.WEEK_VIEW
+        assertShowWeekViewSuccess("WEEK"); // Case insensitive -> Success
+        assertShowWeekViewSuccess("  Week  "); //Trailing whitespaces -> Success
+    }
+
+    @Test
+    public void execute_showMonthView_success() {
+        assertShowMonthViewSuccess("Month"); // Matches exact keyword in ViewCalendarCommand.MONTH_VIEW
+        assertShowMonthViewSuccess("MONTH"); // Case insensitive -> Success
+        assertShowMonthViewSuccess("  month  "); //Trailing whitespaces -> Success
+    }
+
+    @Test
+    public void equals() {
+        ViewCalendarCommand viewCalendarFirstCommand = new ViewCalendarCommand(ViewCalendarCommand.DAY_VIEW);
+        ViewCalendarCommand viewCalendarSecondCommand = new ViewCalendarCommand(ViewCalendarCommand.WEEK_VIEW);
+
+        // same object -> returns true
+        assertTrue(viewCalendarFirstCommand.equals(viewCalendarFirstCommand));
+
+        // same values -> returns true
+        ViewCalendarCommand selectFirstCommandCopy = new ViewCalendarCommand(ViewCalendarCommand.DAY_VIEW);
+        assertTrue(viewCalendarFirstCommand.equals(selectFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(viewCalendarFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(viewCalendarFirstCommand.equals(null));
+
+        // different view -> returns false
+        assertFalse(viewCalendarFirstCommand.equals(viewCalendarSecondCommand));
+    }
+
+    /**
+     * Executes a {@code ViewCalendarCommand} with the given {@code view},
+     * and checks that {@code DisplayCalendarRequestEvent} is raised with the day view.
+     */
+    private void assertShowDayViewSuccess(String view) {
+        ViewCalendarCommand viewCalendarCommand = new ViewCalendarCommand(view);
+
+        try {
+            CommandResult commandResult = viewCalendarCommand.execute();
+            assertEquals(String.format(ViewCalendarCommand.MESSAGE_SHOW_CALENDAR_SUCCESS, ViewCalendarCommand.DAY_VIEW),
+                    commandResult.feedbackToUser);
+        } catch (CommandException ce) {
+            throw new IllegalArgumentException("Execution of command should not fail.", ce);
+        }
+
+        DisplayCalendarRequestEvent lastEvent = (DisplayCalendarRequestEvent) eventsCollectorRule.eventsCollector
+                .getMostRecent();
+        assertEquals(ViewCalendarCommand.DAY_VIEW, lastEvent.getView());
+    }
+
+    /**
+     * Executes a {@code ViewCalendarCommand} with the given {@code view},
+     * and checks that {@code DisplayCalendarRequestEvent} is raised with the week view.
+     */
+    private void assertShowWeekViewSuccess(String view) {
+        ViewCalendarCommand viewCalendarCommand = new ViewCalendarCommand(view);
+
+        try {
+            CommandResult commandResult = viewCalendarCommand.execute();
+            assertEquals(String.format(ViewCalendarCommand.MESSAGE_SHOW_CALENDAR_SUCCESS,
+                    ViewCalendarCommand.WEEK_VIEW), commandResult.feedbackToUser);
+        } catch (CommandException ce) {
+            throw new IllegalArgumentException("Execution of command should not fail.", ce);
+        }
+
+        DisplayCalendarRequestEvent lastEvent = (DisplayCalendarRequestEvent) eventsCollectorRule.eventsCollector
+                .getMostRecent();
+        assertEquals(ViewCalendarCommand.WEEK_VIEW, lastEvent.getView());
+    }
+
+    /**
+     * Executes a {@code ViewCalendarCommand} with the given {@code view},
+     * and checks that {@code DisplayCalendarRequestEvent} is raised with the month view.
+     */
+    private void assertShowMonthViewSuccess(String view) {
+        ViewCalendarCommand viewCalendarCommand = new ViewCalendarCommand(view);
+
+        try {
+            CommandResult commandResult = viewCalendarCommand.execute();
+            assertEquals(String.format(ViewCalendarCommand.MESSAGE_SHOW_CALENDAR_SUCCESS,
+                    ViewCalendarCommand.MONTH_VIEW), commandResult.feedbackToUser);
+        } catch (CommandException ce) {
+            throw new IllegalArgumentException("Execution of command should not fail.", ce);
+        }
+
+        DisplayCalendarRequestEvent lastEvent = (DisplayCalendarRequestEvent) eventsCollectorRule.eventsCollector
+                .getMostRecent();
+        assertEquals(ViewCalendarCommand.MONTH_VIEW, lastEvent.getView());
+    }
 
 }

--- a/src/test/java/seedu/address/logic/commands/ViewNextCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewNextCommandTest.java
@@ -1,0 +1,61 @@
+package seedu.address.logic.commands;
+//@@author SuxianAlicia
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import seedu.address.commons.events.ui.ChangeCalendarPageRequestEvent;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.ui.testutil.EventsCollectorRule;
+
+public class ViewNextCommandTest {
+
+    @Rule
+    public final EventsCollectorRule eventsCollectorRule = new EventsCollectorRule();
+
+    @Test
+    public void execute_viewNextCommand_success() {
+        assertShowNextPageSuccess();
+    }
+
+    @Test
+    public void equals() {
+        ViewNextCommand viewNextFirstCommand = new ViewNextCommand();
+
+        // same object -> returns true
+        assertTrue(viewNextFirstCommand.equals(viewNextFirstCommand));
+
+        // same values -> returns true
+        ViewNextCommand viewNextFirstCommandCopy = new ViewNextCommand();
+        assertTrue(viewNextFirstCommand.equals(viewNextFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(viewNextFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(viewNextFirstCommand.equals(null));
+    }
+
+    /**
+     * Executes a {@code ViewNextCommand},
+     * and checks that {@code ChangeCalendarPageRequestEvent} is raised with the Request Type "Next".
+     */
+    private void assertShowNextPageSuccess() {
+        ViewNextCommand viewNextCommand = new ViewNextCommand();
+
+        try {
+            CommandResult commandResult = viewNextCommand.execute();
+            assertEquals(ViewNextCommand.MESSAGE_VIEW_CALENDAR_NEXT_SUCCESS,
+                    commandResult.feedbackToUser);
+        } catch (CommandException ce) {
+            throw new IllegalArgumentException("Execution of command should not fail.", ce);
+        }
+
+        ChangeCalendarPageRequestEvent lastEvent = (ChangeCalendarPageRequestEvent) eventsCollectorRule.eventsCollector
+                .getMostRecent();
+        assertEquals(ViewNextCommand.REQUEST_NEXT, lastEvent.getRequestType());
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/ViewTodayCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ViewTodayCommandTest.java
@@ -1,0 +1,61 @@
+package seedu.address.logic.commands;
+//@@author SuxianAlicia
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Rule;
+import org.junit.Test;
+
+import seedu.address.commons.events.ui.ChangeCalendarPageRequestEvent;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.ui.testutil.EventsCollectorRule;
+
+public class ViewTodayCommandTest {
+
+    @Rule
+    public final EventsCollectorRule eventsCollectorRule = new EventsCollectorRule();
+
+    @Test
+    public void execute_viewTodayCommand_success() {
+        assertShowTodaySuccess();
+    }
+
+    @Test
+    public void equals() {
+        ViewTodayCommand viewTodayCommand = new ViewTodayCommand();
+
+        // same object -> returns true
+        assertTrue(viewTodayCommand.equals(viewTodayCommand));
+
+        // same values -> returns true
+        ViewTodayCommand viewTodayCommandCopy = new ViewTodayCommand();
+        assertTrue(viewTodayCommand.equals(viewTodayCommandCopy));
+
+        // different types -> returns false
+        assertFalse(viewTodayCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(viewTodayCommand.equals(null));
+    }
+
+    /**
+     * Executes a {@code ViewTodayCommand},
+     * and checks that {@code ChangeCalendarPageRequestEvent} is raised with the Request Type "Today".
+     */
+    private void assertShowTodaySuccess() {
+        ViewTodayCommand viewNextCommand = new ViewTodayCommand();
+
+        try {
+            CommandResult commandResult = viewNextCommand.execute();
+            assertEquals(ViewTodayCommand.MESSAGE_VIEW_CALENDAR_TODAY_SUCCESS,
+                    commandResult.feedbackToUser);
+        } catch (CommandException ce) {
+            throw new IllegalArgumentException("Execution of command should not fail.", ce);
+        }
+
+        ChangeCalendarPageRequestEvent lastEvent = (ChangeCalendarPageRequestEvent) eventsCollectorRule.eventsCollector
+                .getMostRecent();
+        assertEquals(ViewTodayCommand.REQUEST_TODAY, lastEvent.getRequestType());
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -46,7 +46,10 @@ import seedu.address.logic.commands.ListOrderCommand;
 import seedu.address.logic.commands.RedoCommand;
 import seedu.address.logic.commands.SelectCommand;
 import seedu.address.logic.commands.UndoCommand;
+import seedu.address.logic.commands.ViewBackCommand;
 import seedu.address.logic.commands.ViewCalendarCommand;
+import seedu.address.logic.commands.ViewNextCommand;
+import seedu.address.logic.commands.ViewTodayCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.event.CalendarEntry;
 import seedu.address.model.order.Order;
@@ -441,6 +444,42 @@ public class AddressBookParserTest {
     public void parseCommand_viewCalendarCommandAlias_returnsViewCalendarCommand() throws Exception {
         assertTrue(parser.parseCommand(ViewCalendarCommand.COMMAND_ALIAS) instanceof ViewCalendarCommand);
         assertTrue(parser.parseCommand("cal DAY") instanceof ViewCalendarCommand);
+    }
+
+    @Test
+    public void parseCommand_viewBackCommand_returnsViewBackCommand() throws Exception {
+        assertTrue(parser.parseCommand(ViewBackCommand.COMMAND_WORD) instanceof ViewBackCommand);
+        assertTrue(parser.parseCommand("calendarback 2") instanceof ViewBackCommand);
+    }
+
+    @Test
+    public void parseCommand_viewBackCommandAlias_returnsViewBackCommand() throws Exception {
+        assertTrue(parser.parseCommand(ViewBackCommand.COMMAND_ALIAS) instanceof ViewBackCommand);
+        assertTrue(parser.parseCommand("calback 2") instanceof ViewBackCommand);
+    }
+
+    @Test
+    public void parseCommand_viewNextCommand_returnsViewNextCommand() throws Exception {
+        assertTrue(parser.parseCommand(ViewNextCommand.COMMAND_WORD) instanceof ViewNextCommand);
+        assertTrue(parser.parseCommand("calendarnext 1") instanceof ViewNextCommand);
+    }
+
+    @Test
+    public void parseCommand_viewNextCommandAlias_returnsViewNextCommand() throws Exception {
+        assertTrue(parser.parseCommand(ViewNextCommand.COMMAND_ALIAS) instanceof ViewNextCommand);
+        assertTrue(parser.parseCommand("calnext 1") instanceof ViewNextCommand);
+    }
+
+    @Test
+    public void parseCommand_viewTodayCommand_returnsViewTodayCommand() throws Exception {
+        assertTrue(parser.parseCommand(ViewTodayCommand.COMMAND_WORD) instanceof ViewTodayCommand);
+        assertTrue(parser.parseCommand("calendartoday 5") instanceof ViewTodayCommand);
+    }
+
+    @Test
+    public void parseCommand_viewTodayCommandAlias_returnsViewTodayCommand() throws Exception {
+        assertTrue(parser.parseCommand(ViewTodayCommand.COMMAND_ALIAS) instanceof ViewTodayCommand);
+        assertTrue(parser.parseCommand("caltoday 5") instanceof ViewTodayCommand);
     }
 
     @Test

--- a/src/test/java/seedu/address/ui/CalendarEntryCardTest.java
+++ b/src/test/java/seedu/address/ui/CalendarEntryCardTest.java
@@ -1,5 +1,5 @@
 package seedu.address.ui;
-
+//@@author SuxianAlicia
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;

--- a/src/test/java/seedu/address/ui/CalendarEntryListPanelTest.java
+++ b/src/test/java/seedu/address/ui/CalendarEntryListPanelTest.java
@@ -1,5 +1,5 @@
 package seedu.address.ui;
-
+//@@author SuxianAlicia
 import static org.junit.Assert.assertEquals;
 import static seedu.address.testutil.TypicalCalendarEntries.getTypicalCalendarEntries;
 import static seedu.address.ui.testutil.GuiTestAssert.assertCardDisplaysEntry;


### PR DESCRIPTION
Gives CLI equivalent commands for the Calendar Buttons.
ViewTodayCommand: Switches displayed date in calendar to Today's date. [Today] Button
ViewBackCommand: Switches current page of calendar to previous page. [<] Button
ViewNextCommand: Switches current page of calendar to next page. [>] Button

Added tests for these new commands and for ViewCalendarCommand.
Relates to #138 .